### PR TITLE
sample qa tests, repository layout

### DIFF
--- a/tests/qa/classes/StringTest.gd
+++ b/tests/qa/classes/StringTest.gd
@@ -1,0 +1,182 @@
+extends MainLoop
+
+var test_string = 'Lorem Ipsum'
+
+var unix_root = '/'
+var unix_file_sans_extension = '/abc.def/ghi'
+var unix_file_with_extension = '/abc.def/ghi.jkl'
+var unix_dir = '/abc.def/ghi.jkl/'
+
+var windows_root = 'C:/'
+var windows_file_sans_extension = 'C:/abc.def/ghi'
+var windows_file_with_extension = 'C:/abc.def/ghi.jkl'
+var windows_dir = 'C:/abc.def/ghi.jkl/'
+
+# main test body
+func _iteration(delta):
+	test_begins_with_test_string()
+	test_ends_with_test_string()
+	
+	test_find_test_string()
+	
+	test_get_base_dir_test_string()
+	test_get_base_dir_unix_root()
+	test_get_base_dir_unix_file_sans_extension()
+	test_get_base_dir_unix_file_with_extension()
+	test_get_base_dir_unix_dir()
+	test_get_base_dir_windows_root()
+	test_get_base_dir_windows_file_sans_extension()
+	test_get_base_dir_windows_file_with_extension()
+	test_get_base_dir_windows_dir()
+	
+	test_get_basename_test_string()
+	test_get_basename_unix_root()
+	test_get_basename_unix_file_sans_extension()
+	test_get_basename_unix_file_with_extension()
+	test_get_basename_unix_dir()
+	test_get_basename_windows_root()
+	test_get_basename_windows_file_sans_extension()
+	test_get_basename_windows_file_with_extension()
+	test_get_basename_windows_dir()
+	
+	test_get_extension_test_string()
+	test_get_extension_unix_root()
+	test_get_extension_unix_file_sans_extension()
+	test_get_extension_unix_file_with_extension()
+	test_get_extension_unix_dir()
+	test_get_extension_windows_root()
+	test_get_extension_windows_file_sans_extension()
+	test_get_extension_windows_file_with_extension()
+	test_get_extension_windows_dir()
+	
+	return true # exit MainLoop
+
+func test_begins_with_test_string():
+	assert(test_string.begins_with('Lorem') == true)
+	assert(test_string.begins_with('Ipsum') == false)
+
+func test_ends_with_test_string():
+	assert(test_string.ends_with('Lorem') == false)
+	assert(test_string.ends_with('Ipsum') == true)
+
+func test_find_test_string():
+	# default index value test
+	assert(test_string.find(' ', 0) == test_string.find(' '))
+	
+	# index value out of bounds
+	assert(test_string.find(' ', -1) == -1)
+	assert(test_string.find(' ', test_string.length()) == -1)
+	
+	# bad sub string test
+	#assert(test_string.find(null) == -1) # parser doesn't allow
+	assert(test_string.find('') == -1)
+	
+	# bounds checking
+	assert(test_string.find(' ', 5) == 5)
+	assert(test_string.find(' ', 6) == -1)
+	
+	# multi character sub string test
+	assert(test_string.find('Ip') == 6)
+
+# test_get_base_dir
+
+func test_get_base_dir_test_string():
+	# not really a fair test, but highlights API mismatch
+	#assert(test_string.get_base_dir() == '')
+	pass
+	
+func test_get_base_dir_unix_root():
+	assert(unix_root.get_base_dir() == unix_root)
+	
+func test_get_base_dir_unix_file_sans_extension():
+	assert(unix_file_sans_extension.get_base_dir() == '/abc.def')
+	
+func test_get_base_dir_unix_file_with_extension():
+	assert(unix_file_with_extension.get_base_dir() == '/abc.def')
+	
+func test_get_base_dir_unix_dir():
+	assert(unix_dir.get_base_dir() == unix_file_with_extension)
+	
+func test_get_base_dir_windows_root():
+	assert(windows_root.get_base_dir() == 'C:') # hmmm
+	
+func test_get_base_dir_windows_file_sans_extension():
+	assert(windows_file_sans_extension.get_base_dir() == 'C:/abc.def')
+	
+func test_get_base_dir_windows_file_with_extension():
+	assert(windows_file_with_extension.get_base_dir() == 'C:/abc.def')
+	
+func test_get_base_dir_windows_dir():
+	assert(windows_dir.get_base_dir() == windows_file_with_extension)
+
+# test_get_basename
+
+func test_get_basename_test_string():
+	# not really a fair test, but highlights API mismatch
+	#assert(test_string.get_basename() == '') # bug, not a path
+	pass
+	
+func test_get_basename_unix_root():
+	assert(unix_root.get_basename() == unix_root)
+	
+func test_get_basename_unix_file_sans_extension():
+	print(unix_file_sans_extension.get_basename(), ' == ', unix_file_sans_extension)
+	assert(unix_file_sans_extension.get_basename() == unix_file_sans_extension) # bug, file w/o extension
+	
+func test_get_basename_unix_file_with_extension():
+	assert(unix_file_with_extension.get_basename() == unix_file_sans_extension)
+	
+func test_get_basename_unix_dir():
+	print(unix_dir.get_basename(), ' == ', unix_dir)
+	assert(unix_dir.get_basename() == unix_dir) # bug, directory
+	
+func test_get_basename_windows_root():
+	assert(windows_root.get_basename() == windows_root)
+	
+func test_get_basename_windows_file_sans_extension():
+	print(windows_file_sans_extension.get_basename(), ' == ', windows_file_sans_extension)
+	assert(windows_file_sans_extension.get_basename() == windows_file_sans_extension) # bug, file w/o extension, dupe
+	
+func test_get_basename_windows_file_with_extension():
+	assert(windows_file_with_extension.get_basename() == windows_file_sans_extension)
+	
+func test_get_basename_windows_dir():
+	print(windows_dir.get_basename(), ' == ', windows_dir)
+	assert(windows_dir.get_basename() == windows_dir) # bug, directory, dupe
+
+# test_get_extension
+
+func test_get_extension_test_string():
+	# not really a fair test, but highlights API mismatch
+	#assert(test_string.get_extension() == '') # bug, not a path
+	pass
+	
+func test_get_extension_unix_root():
+	print(unix_root.get_extension(), ' == ', '<empty>')
+	assert(unix_root.get_extension() == '') # bug, not a file
+	
+func test_get_extension_unix_file_sans_extension():
+	print(unix_file_sans_extension.get_extension(), ' == ', '<empty>')
+	assert(unix_file_sans_extension.get_extension() == '') # bug, file w/o extension
+	
+func test_get_extension_unix_file_with_extension():
+	assert(unix_file_with_extension.get_extension() == 'jkl')
+	
+func test_get_extension_unix_dir():
+	print(unix_dir.get_extension(), ' == ', '<empty>')
+	assert(unix_dir.get_extension() == '') # bug, not a file, dupe
+	
+func test_get_extension_windows_root():
+	print(windows_root.get_extension(), ' == ', '<empty>')
+	assert(windows_root.get_extension() == '') # bug, not a file, dupe
+	
+func test_get_extension_windows_file_sans_extension():
+	print(windows_file_sans_extension.get_extension(), ' == ', '<empty>')
+	assert(windows_file_sans_extension.get_extension() == '') # bug, file w/o extension, dupe
+	
+func test_get_extension_windows_file_with_extension():
+	assert(windows_file_with_extension.get_extension() == 'jkl')
+	
+func test_get_extension_windows_dir():
+	print(windows_dir.get_extension(), ' == ', '<empty>')
+	assert(windows_dir.get_extension() == '') # bug, not a file, dupe

--- a/tests/qa/classes/UndoRedoTest.gd
+++ b/tests/qa/classes/UndoRedoTest.gd
@@ -1,0 +1,111 @@
+extends MainLoop
+
+var testobject1
+var undoredo
+
+func _initialize():
+	testobject1 = TestClass.new()
+	testobject1.set_prop(1)
+	
+	undoredo = UndoRedo.new()
+
+# main test body
+func _iteration(delta):
+	test_create_empty()
+	test_create_method()
+	test_create_property()
+	
+	test_undo_one()
+	test_undo_two()
+	
+	test_redo()
+	
+	test_undo_more()
+	
+	test_create_create_bug()
+	
+	return true # exit MainLoop
+
+func _finalize():
+	undoredo.free()
+
+func test_create_empty():
+	undoredo.create_action('noop action')
+	undoredo.commit_action()
+	
+	assert(testobject1.prop == 1)
+
+func test_create_method():
+	undoredo.create_action('first action - method')
+	undoredo.add_do_method(testobject1, 'set_prop', 2)
+	undoredo.add_undo_method(testobject1, 'set_prop', testobject1.get_prop())
+	undoredo.commit_action()
+	
+	assert(testobject1.prop == 2)
+
+func test_create_property():
+	undoredo.create_action('second action - property')
+	undoredo.add_do_property(testobject1, 'prop', 3)
+	undoredo.add_undo_property(testobject1, 'prop', testobject1.prop)
+	undoredo.commit_action()
+	
+	assert(testobject1.prop == 3)
+
+func test_undo_one():
+	undoredo.undo()
+	
+	assert(testobject1.prop == 2)
+
+func test_undo_two():
+	undoredo.undo()
+	
+	assert(testobject1.prop == 1)
+
+func test_redo():
+	undoredo.redo()
+	
+	assert(testobject1.prop == 2)
+
+func test_undo_more():
+	undoredo.undo() # this should be our noop action now
+	assert(testobject1.prop == 1)
+	
+	undoredo.undo() # this should be a Godot noop
+	assert(testobject1.prop == 1)
+	
+	undoredo.redo() # our noop action again
+	assert(testobject1.prop == 1)
+	
+	undoredo.redo() # first action
+	assert(testobject1.prop == 2)
+	
+	undoredo.redo() # second action
+	assert(testobject1.prop == 3)
+	
+	undoredo.redo() # this should be a Godot noop
+	assert(testobject1.prop == 3)
+
+func test_create_create_bug():
+	undoredo.create_action('botched action')
+	# how to cancel/rollback unwanted action?
+	
+	undoredo.create_action('third action')
+	undoredo.add_do_property(testobject1, 'prop', 4)
+	undoredo.add_undo_property(testobject1, 'prop', testobject1.prop)
+	undoredo.commit_action()
+	
+	assert(testobject1.prop == 4)
+	
+	undoredo.redo() # a noop
+	undoredo.undo() # second action
+	
+	assert(testobject1.prop == 3)
+
+class TestClass:
+	var prop
+	
+	func get_prop():
+		return prop
+	
+	func set_prop(prop):
+		self.prop = prop

--- a/tests/qa/issues/14799.gd
+++ b/tests/qa/issues/14799.gd
@@ -1,0 +1,10 @@
+extends MainLoop
+
+# main test body
+func _iteration(delta):
+	test_14799()
+	
+	return true # exit MainLoop
+
+func test_14799():
+	assert('1 2 3 4 5'.split(' ').size() == 5)

--- a/tests/qa/issues/15149.gd
+++ b/tests/qa/issues/15149.gd
@@ -1,0 +1,66 @@
+extends SceneTree
+
+func _init(): # Object
+	VisualServer.set_debug_generate_wireframes(true) # this
+
+func _initialize(): # MainLoop
+	var viewport = get_root()
+	
+	var environment = Environment.new()
+	environment.background_mode = Environment.BG_SKY
+	environment.background_sky = ProceduralSky.new()
+	
+	viewport.world.environment = environment
+	
+	var camera = Camera.new()
+	
+	var mesh_instance = MeshInstance.new()
+	mesh_instance.mesh = CubeMesh.new()
+	mesh_instance.transform.origin.z = -5
+	
+	camera.add_child(mesh_instance)
+	
+	viewport.add_child(camera)
+
+var before_image
+var after_image
+
+# it takes 6 _iterations to have usable viewport texture data, add buffer
+const DELAY_CYCLES = 6 * 2
+
+var delay = DELAY_CYCLES
+
+# main test body
+func _iteration(delta): # MainLoop
+	if delay > 0:
+		delay -= 1
+		
+		return false # return true in MainLoop exits, keep going?
+	
+	var viewport = get_root()
+	
+	if !before_image:
+		before_image = viewport.get_texture().get_data()
+		#before_image.flip_y()
+		#before_image.save_png('/tmp/15149.1_before_image.png')
+		
+		viewport.debug_draw = Viewport.DEBUG_DRAW_WIREFRAME
+		
+		delay = DELAY_CYCLES
+		
+		return false
+	
+	after_image = viewport.get_texture().get_data()
+	#after_image.flip_y()
+	#after_image.save_png('/tmp/15149.2_after_image.png')
+	
+	test_viewport_wireframe()
+	
+	quit()
+
+func test_viewport_wireframe():
+	# issue 15378 bites us
+	#assert(before_image.get_data() != after_image.get_data())
+	assert(!(before_image.get_data() == after_image.get_data()))
+	
+	# we could also save a known-good copy and assert the after_image matches

--- a/tests/qa/issues/15166.gd
+++ b/tests/qa/issues/15166.gd
@@ -1,0 +1,31 @@
+extends SceneTree
+
+func _initialize(): # MainLoop
+	var viewport = get_root()
+	
+	var color_rect = ColorRect.new()
+	color_rect.rect_size = viewport.get_visible_rect().size
+	
+	var shader = Shader.new()
+	shader.set_code("""
+		shader_type canvas_item;
+		
+		uniform vec2 thing = vec2(1.0); // bug
+	""")
+	
+	var material = ShaderMaterial.new()
+	material.set_shader(shader)
+	
+	color_rect.material = material
+	
+	viewport.add_child(color_rect)
+
+# main test body
+func _iteration(delta): # MainLoop
+	test_shader_vec2_constructor()
+	
+	quit()
+
+func test_shader_vec2_constructor():
+	# how would we test for a shader compiler error?
+	assert(true)

--- a/tests/qa/issues/15374.gd
+++ b/tests/qa/issues/15374.gd
@@ -1,0 +1,21 @@
+extends MainLoop
+
+# main test body
+func _iteration(delta):
+	test_set_pixel_docs()
+	test_resize_crash()
+	
+	return true # exit MainLoop
+
+func test_set_pixel_docs():
+	var image = Image.new()
+	image.create(1, 1, false, Image.FORMAT_RGBA8) # docs
+	image.lock()
+	image.set_pixel(0, 0, Color(1, 0, 0, 1))
+	image.unlock()
+	assert(true)
+
+func test_resize_crash():
+	var image = Image.new()
+	image.resize(1, 1) # crash
+	assert(true)

--- a/tests/qa/issues/15378.gd
+++ b/tests/qa/issues/15378.gd
@@ -1,0 +1,69 @@
+extends MainLoop
+
+var basearray1 = [1, 2, 3]
+var basearray2 = Array([1, 2, 3])
+var basearray3 = [1, 3, 3]
+var basearray4 = [4, 5, 6]
+
+var pba1 = PoolByteArray(basearray1)
+var pba2 = PoolByteArray(basearray2)
+var pba3 = PoolByteArray(basearray3)
+var pba4 = PoolByteArray(basearray4)
+
+var image1
+var image2
+var image3
+
+func _initialize():
+	image1 = Image.new()
+	image1.create(1, 1, false, Image.FORMAT_RGBA8)
+	image1.lock()
+	image1.set_pixel(0, 0, Color(1, 0, 0, 1))
+	image1.unlock()
+	
+	image2 = Image.new()
+	image2.create(1, 1, false, Image.FORMAT_RGBA8)
+	image2.lock()
+	image2.set_pixel(0, 0, Color(1, 0, 0, 1))
+	image2.unlock()
+	
+	image3 = Image.new()
+	image3.create(1, 1, false, Image.FORMAT_RGBA8)
+	image3.lock()
+	image3.set_pixel(0, 0, Color(0, 1, 0, 1))
+	image3.unlock()
+
+# main test body
+func _iteration(delta):
+	test_array_comparison()
+	test_pba_comparison()
+	test_image_pba_comparison()
+	
+	return true # exit MainLoop
+
+func test_array_comparison():
+	assert(basearray1 == basearray2)
+	assert(!(basearray1 != basearray2))
+	
+	assert(basearray1 != basearray3) # mrcdk issue (root)
+	assert(!(basearray1 == basearray3))
+	
+	assert(basearray1 != basearray4)
+	assert(!(basearray1 == basearray4))
+
+func test_pba_comparison():
+	assert(pba1 == pba2)
+	assert(!(pba1 != pba2))
+	
+	assert(pba1 != pba3) # mrcdk issue (root)
+	assert(!(pba1 == pba3))
+	
+	assert(pba1 != pba4)
+	assert(!(pba1 == pba4))
+
+func test_image_pba_comparison():
+	assert(image1.get_data() == image2.get_data())
+	assert(!(image1.get_data() != image2.get_data()))
+	
+	assert(image1.get_data() != image3.get_data()) # original issue
+	assert(!(image1.get_data() == image3.get_data()))

--- a/tests/qa/issues/15424.gd
+++ b/tests/qa/issues/15424.gd
@@ -1,0 +1,24 @@
+extends MainLoop
+
+var testobject1
+
+# main test body
+func _iteration(delta):
+	test_undoredo_crash()
+	
+	return true # exit MainLoop
+
+func test_undoredo_crash():
+	var undoredo = UndoRedo.new()
+	
+	undoredo.create_action('test')
+	undoredo.add_do_property(testobject1, 'prop', []) # crash
+	undoredo.add_do_method(testobject1, 'prop', []) # good
+	undoredo.add_do_reference(testobject1) # crash
+	undoredo.add_undo_property(testobject1, 'prop', []) # crash
+	undoredo.add_undo_method(testobject1, 'prop', []) # good
+	undoredo.add_undo_reference(testobject1) # crash
+	
+	undoredo.free()
+	
+	assert(true)


### PR DESCRIPTION
Inspired by [#2641](https://github.com/godotengine/godot/issues/2641).  General quality assurance discussion [here](https://github.com/godotengine/godot-tests/issues/4).

Issues:

- [x] Cleanly exit the test
~~ - [ ] More descriptive errors; suitable for reporting ~~

To Do:
- [x] Add more tests (added issue examples)

### Classes String Test

```
todd@todd-ab28d3:~/repos/remote/brainsick-godot-tests$ time ../brainsick-godot/bin/godot.x11.tools.64 -s tests/qa/classes/StringTest.gd
No touch devices found
OpenGL ES 3.0 Renderer: AMD Radeon (TM) R9 Fury Series (AMD FIJI / DRM 3.18.0 / 4.13.0-21-generic, LLVM 5.0.0)
GLES3: max ubo light: 409
GLES3: max ubo reflections: 455, ubo size: 144
ARVR: Registered interface: Native mobile
SCRIPT ERROR: test_get_basename_unix_file_sans_extension: Assertion failed.
   At: res://tests/qa/classes/StringTest.gd:123.
SCRIPT ERROR: test_get_basename_unix_dir: Assertion failed.
   At: res://tests/qa/classes/StringTest.gd:129.
SCRIPT ERROR: test_get_basename_windows_file_sans_extension: Assertion failed.
   At: res://tests/qa/classes/StringTest.gd:135.
SCRIPT ERROR: test_get_basename_windows_dir: Assertion failed.
   At: res://tests/qa/classes/StringTest.gd:141.
SCRIPT ERROR: test_get_extension_unix_root: Assertion failed.
   At: res://tests/qa/classes/StringTest.gd:151.
SCRIPT ERROR: test_get_extension_unix_file_sans_extension: Assertion failed.
   At: res://tests/qa/classes/StringTest.gd:154.
SCRIPT ERROR: test_get_extension_unix_dir: Assertion failed.
   At: res://tests/qa/classes/StringTest.gd:160.
SCRIPT ERROR: test_get_extension_windows_root: Assertion failed.
   At: res://tests/qa/classes/StringTest.gd:163.
SCRIPT ERROR: test_get_extension_windows_file_sans_extension: Assertion failed.
   At: res://tests/qa/classes/StringTest.gd:166.
SCRIPT ERROR: test_get_extension_windows_dir: Assertion failed.
   At: res://tests/qa/classes/StringTest.gd:172.

real	0m1.153s
user	0m0.157s
sys	0m0.029s
```

This spawned issue godotengine/godot#15471.

### Classes UndoRedo Test

Inspired by godotengine/godot#11785.

```
todd@todd-ab28d3:~/repos/remote/brainsick-godot-tests$ time ../brainsick-godot/bin/godot.x11.tools.64 -s tests/qa/classes/UndoRedoTest.gd 
No touch devices found
OpenGL ES 3.0 Renderer: AMD Radeon (TM) R9 Fury Series (AMD FIJI / DRM 3.18.0 / 4.13.0-21-generic, LLVM 5.0.0)
GLES3: max ubo light: 409
GLES3: max ubo reflections: 455, ubo size: 144
ARVR: Registered interface: Native mobile
SCRIPT ERROR: test_create_create_bug: Assertion failed.
   At: res://tests/qa/classes/UndoRedoTest.gd:77.
ERROR: clear_history: Condition ' action_level > 0 ' is true.
   At: core/undo_redo.cpp:326.

real	0m1.161s
user	0m0.163s
sys	0m0.025s
```

This spawned issue godotengine/godot#15424.
This spawned issue godotengine/godot#15460.
This spawned issue godotengine/godot#15506.

### Issue godotengine/godot#14799 Test
Just an example.  This probably belongs in a Class Test.

```
todd@todd-ab28d3:~/repos/remote/brainsick-godot-tests/tests/qa$ time ~/Downloads/Godot3.0Beta2/Godot_v3.0-beta2_x11.64 -s issues/14799.gd 
No touch devices found
OpenGL ES 3.0 Renderer: AMD Radeon (TM) R9 Fury Series (AMD FIJI / DRM 3.18.0 / 4.13.0-21-generic, LLVM 5.0.0)
GLES3: max ubo light: 409
GLES3: max ubo reflections: 455, ubo size: 144
ARVR: Registered interface: Native mobile
SCRIPT ERROR: test_14799: Assertion failed.
   At: res://issues/14799.gd:10.

real	0m1.118s
user	0m0.078s
sys	0m0.020s
```

### Issue godotengine/godot#15166 Test - Shader Crash

```
todd@todd-ab28d3:~/repos/remote/brainsick-godot-tests/tests/qa$ time ~/Downloads/Godot3.0Beta2/Godot_v3.0-beta2_x11.64 -s issues/15166.gd 
No touch devices found
OpenGL ES 3.0 Renderer: AMD Radeon (TM) R9 Fury Series (AMD FIJI / DRM 3.18.0 / 4.13.0-21-generic, LLVM 5.0.0)
GLES3: max ubo light: 409
GLES3: max ubo reflections: 455, ubo size: 144
ARVR: Registered interface: Native mobile
ERROR: operator[]: FATAL: Index p_index=1 out of size (size()=1)
   At: core/vector.h:146.
handle_crash: Program crashed with signal 4
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[1] /lib/x86_64-linux-gnu/libc.so.6(+0x37140) [0x7f55fa419140] (??:0)
[2] /home/todd/Downloads/Godot3.0Beta2/Godot_v3.0-beta2_x11.64() [0x482e7b] (??:0)
[3] /home/todd/Downloads/Godot3.0Beta2/Godot_v3.0-beta2_x11.64() [0xa224c5] (??:?)
[4] /home/todd/Downloads/Godot3.0Beta2/Godot_v3.0-beta2_x11.64() [0xa22a0c] (??:?)
[5] /home/todd/Downloads/Godot3.0Beta2/Godot_v3.0-beta2_x11.64() [0x9cfee3] (??:?)
[6] /home/todd/Downloads/Godot3.0Beta2/Godot_v3.0-beta2_x11.64() [0x18933b7] (??:?)
[7] /home/todd/Downloads/Godot3.0Beta2/Godot_v3.0-beta2_x11.64() [0x4c04f5] (??:0)
[8] /home/todd/Downloads/Godot3.0Beta2/Godot_v3.0-beta2_x11.64() [0x44f38d] (??:0)
[9] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf1) [0x7f55fa4031c1] (??:0)
[10] /home/todd/Downloads/Godot3.0Beta2/Godot_v3.0-beta2_x11.64() [0x45ad3f] (??:0)
-- END OF BACKTRACE --
Aborted (core dumped)

real	0m0.413s
user	0m0.207s
sys	0m0.042s
```

### Issue godotengine/godot#15149 Test - Wireframe Mode
The beginning of a simple image comparison test.  Could be combined with the shader test to monitor shader output.

```
todd@todd-ab28d3:~/repos/remote/brainsick-godot-tests$ time ../brainsick-godot/bin/godot.x11.tools.64 -s tests/qa/issues/15149.gd
No touch devices found
OpenGL ES 3.0 Renderer: AMD Radeon (TM) R9 Fury Series (AMD FIJI / DRM 3.18.0 / 4.13.0-21-generic, LLVM 5.0.0)
GLES3: max ubo light: 409
GLES3: max ubo reflections: 455, ubo size: 144
ARVR: Registered interface: Native mobile

real	0m1.151s
user	0m0.709s
sys	0m0.048s
```
![15149 1_before_image](https://user-images.githubusercontent.com/1111573/34585657-4ca87572-f166-11e7-93db-3a911a52ea4d.png)
![15149 2_after_image](https://user-images.githubusercontent.com/1111573/34585662-4eec5312-f166-11e7-9f4f-34886e814235.png)

This spawned issue godotengine/godot#15378.

### Issue godotengine/godot#15378 Test - PoolDataArray comparisons

```
todd@todd-ab28d3:~/repos/remote/brainsick-godot-tests/tests/qa$ time ~/Downloads/Godot3.0Beta2/Godot_v3.0-beta2_x11.64 -s issues/15378.gd 
No touch devices found
OpenGL ES 3.0 Renderer: AMD Radeon (TM) R9 Fury Series (AMD FIJI / DRM 3.18.0 / 4.13.0-21-generic, LLVM 5.0.0)
GLES3: max ubo light: 409
GLES3: max ubo reflections: 455, ubo size: 144
ARVR: Registered interface: Native mobile
SCRIPT ERROR: test_array_comparison: Assertion failed.
   At: res://issues/15378.gd:48.
SCRIPT ERROR: test_pba_comparison: Assertion failed.
   At: res://issues/15378.gd:58.
SCRIPT ERROR: test_image_pba_comparison: Assertion failed.
   At: res://issues/15378.gd:68.

real	0m1.112s
user	0m0.091s
sys	0m0.013s
```

This spawned issue godotengine/godot#15374.

### Issue godotengine/godot#15374 Test - Image docs and resize crash

```
todd@todd-ab28d3:~/repos/remote/brainsick-godot-tests$ time ../brainsick-godot/bin/godot.x11.tools.64 -s tests/qa/issues/15374.gd
No touch devices found
OpenGL ES 3.0 Renderer: AMD Radeon (TM) R9 Fury Series (AMD FIJI / DRM 3.18.0 / 4.13.0-21-generic, LLVM 5.0.0)
GLES3: max ubo light: 409
GLES3: max ubo reflections: 455, ubo size: 144
ARVR: Registered interface: Native mobile
handle_crash: Program crashed with signal 11
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[1] /lib/x86_64-linux-gnu/libc.so.6(+0x37140) [0x7f2ef3fed140] (??:0)
[2] ../brainsick-godot/bin/godot.x11.tools.64(+0x249076d) [0x55920e59876d] (??:0)
[3] Image::resize(int, int, Image::Interpolation) (??:0)
[4] MethodBind3<int, int, Image::Interpolation>::call(Object*, Variant const**, int, Variant::CallError&) (??:0)
[5] Object::call(StringName const&, Variant const**, int, Variant::CallError&) (??:0)
[6] Variant::call_ptr(StringName const&, Variant const**, int, Variant*, Variant::CallError&) (??:0)
[7] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Variant::CallError&, GDScriptFunction::CallState*) (??:0)
[8] GDScriptInstance::call(StringName const&, Variant const**, int, Variant::CallError&) (??:0)
[9] Object::call(StringName const&, Variant const**, int, Variant::CallError&) (??:0)
[10] Variant::call_ptr(StringName const&, Variant const**, int, Variant*, Variant::CallError&) (??:0)
[11] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Variant::CallError&, GDScriptFunction::CallState*) (??:0)
[12] GDScriptInstance::call(StringName const&, Variant const**, int, Variant::CallError&) (??:0)
[13] ScriptInstance::call(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) (??:0)
[14] MainLoop::iteration(float) (??:0)
[15] Main::iteration() (??:0)
[16] OS_X11::run() (??:0)
[17] ../brainsick-godot/bin/godot.x11.tools.64(main+0xd5) [0x55920ccf67ef] (??:0)
[18] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf1) [0x7f2ef3fd71c1] (??:0)
[19] ../brainsick-godot/bin/godot.x11.tools.64(_start+0x2a) [0x55920ccf663a] (??:0)
-- END OF BACKTRACE --
Aborted (core dumped)

real	0m0.678s
user	0m0.293s
sys	0m0.243s
```

### Issue godotengine/godot#15424 Test - UndoRedo crashes

```
todd@todd-ab28d3:~/repos/remote/brainsick-godot-tests$ time ../brainsick-godot/bin/godot.x11.tools.64 -s tests/qa/issues/15424.gd 
No touch devices found
OpenGL ES 3.0 Renderer: AMD Radeon (TM) R9 Fury Series (AMD FIJI / DRM 3.18.0 / 4.13.0-21-generic, LLVM 5.0.0)
GLES3: max ubo light: 409
GLES3: max ubo reflections: 455, ubo size: 144
ARVR: Registered interface: Native mobile
handle_crash: Program crashed with signal 11
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[1] /lib/x86_64-linux-gnu/libc.so.6(+0x37140) [0x7fde5e01e140] (??:0)
[2] Object::get_instance_id() const (??:0)
[3] UndoRedo::add_do_property(Object*, String const&, Variant const&) (??:0)
[4] MethodBind3<Object*, String const&, Variant const&>::call(Object*, Variant const**, int, Variant::CallError&) (??:0)
[5] Object::call(StringName const&, Variant const**, int, Variant::CallError&) (??:0)
[6] Variant::call_ptr(StringName const&, Variant const**, int, Variant*, Variant::CallError&) (??:0)
[7] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Variant::CallError&, GDScriptFunction::CallState*) (??:0)
[8] GDScriptInstance::call(StringName const&, Variant const**, int, Variant::CallError&) (??:0)
[9] Object::call(StringName const&, Variant const**, int, Variant::CallError&) (??:0)
[10] Variant::call_ptr(StringName const&, Variant const**, int, Variant*, Variant::CallError&) (??:0)
[11] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Variant::CallError&, GDScriptFunction::CallState*) (??:0)
[12] GDScriptInstance::call(StringName const&, Variant const**, int, Variant::CallError&) (??:0)
[13] ScriptInstance::call(StringName const&, Variant const&, Variant const&, Variant const&, Variant const&, Variant const&) (??:0)
[14] MainLoop::iteration(float) (??:0)
[15] Main::iteration() (??:0)
[16] OS_X11::run() (??:0)
[17] ../brainsick-godot/bin/godot.x11.tools.64(main+0xd5) [0x5644a90587ef] (??:0)
[18] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf1) [0x7fde5e0081c1] (??:0)
[19] ../brainsick-godot/bin/godot.x11.tools.64(_start+0x2a) [0x5644a905863a] (??:0)
-- END OF BACKTRACE --
Aborted (core dumped)

real	0m0.669s
user	0m0.318s
sys	0m0.205s
```