### PR TITLE
Use CC-BY for GLTF export_copyright

### DIFF
--- a/tests/blend_export/blend_export.py
+++ b/tests/blend_export/blend_export.py
@@ -21,7 +21,7 @@ for directory in directories:
                 bpy.ops.export_scene.gltf(
                     filepath=export_path,
                     export_format="GLTF_SEPARATE",
-                    export_copyright="The MIT License (MIT) Copyright (c) 2020 Godot Engine",
+                    export_copyright="Creative Commons Attribution 4.0 International Public License 2020 Godot Engine",
                 )
             elif export_type == "fbx":
                 bpy.ops.export_scene.fbx(filepath=export_path)

--- a/tests/blend_export/gltf/32678-respect-import-hints-with-empty.gltf
+++ b/tests/blend_export/gltf/32678-respect-import-hints-with-empty.gltf
@@ -1,6 +1,6 @@
 {
     "asset" : {
-        "copyright" : "The MIT License (MIT) Copyright (c) 2020 Godot Engine",
+        "copyright" : "Creative Commons Attribution 4.0 International Public License 2020 Godot Engine",
         "generator" : "Khronos glTF Blender I/O v1.3.48",
         "version" : "2.0"
     },

--- a/tests/blend_export/gltf/43044-marker.gltf
+++ b/tests/blend_export/gltf/43044-marker.gltf
@@ -1,6 +1,6 @@
 {
     "asset" : {
-        "copyright" : "The MIT License (MIT) Copyright (c) 2020 Godot Engine",
+        "copyright" : "Creative Commons Attribution 4.0 International Public License 2020 Godot Engine",
         "generator" : "Khronos glTF Blender I/O v1.3.48",
         "version" : "2.0"
     },

--- a/tests/blend_export/gltf/43563-asset-collection-test.gltf
+++ b/tests/blend_export/gltf/43563-asset-collection-test.gltf
@@ -1,6 +1,6 @@
 {
     "asset" : {
-        "copyright" : "The MIT License (MIT) Copyright (c) 2020 Godot Engine",
+        "copyright" : "Creative Commons Attribution 4.0 International Public License 2020 Godot Engine",
         "generator" : "Khronos glTF Blender I/O v1.3.48",
         "version" : "2.0"
     },

--- a/tests/blend_export/proposal/gltf/39105-additional-import-hints.gltf
+++ b/tests/blend_export/proposal/gltf/39105-additional-import-hints.gltf
@@ -1,6 +1,6 @@
 {
     "asset" : {
-        "copyright" : "The MIT License (MIT) Copyright (c) 2020 Godot Engine",
+        "copyright" : "Creative Commons Attribution 4.0 International Public License 2020 Godot Engine",
         "generator" : "Khronos glTF Blender I/O v1.3.48",
         "version" : "2.0"
     },


### PR DESCRIPTION
Closes #18.

Other formats do not have the ability to specify copyrights.