### PR TITLE
Add GDScript test for cyclic dependencies

### DIFF
--- a/tests/gdscript/cyclic_compilation/README.md
+++ b/tests/gdscript/cyclic_compilation/README.md
@@ -1,0 +1,7 @@
+The current GDScript unit testing framework does not support using global class names loaded from other files. This test contains a scenario in which that is necessary in order to test for cyclic dependencies in the compilation stage of GDScripts.
+
+This project contains a main scene with a script which forces a very specific order of loading of a cyclic dependency. The cyclic dependency consists of three classes, named `Daughter`, `Mother`, and `Grandmother` with the following connections: `Daughter extends Mother extends Grandmother`. However, `Grandmother uses Daughter`, forming a cyclic dependency including both inheritance as well as mere usage.
+
+The first class loaded is `Mother`, which requires resolving `Grandmother`, which requires resolving `Daughter`. How much each class is resolved, and when, is crucial to successful compilation of this script.
+
+Note: once the unit testing framework supports registering and using global class names from different script files, this test can be moved there.

--- a/tests/gdscript/cyclic_compilation/daughter.gd
+++ b/tests/gdscript/cyclic_compilation/daughter.gd
@@ -1,0 +1,4 @@
+class_name Daughter extends Mother
+
+func parse_error_func() -> void :
+	print(_member)

--- a/tests/gdscript/cyclic_compilation/grand_mother.gd
+++ b/tests/gdscript/cyclic_compilation/grand_mother.gd
@@ -1,0 +1,6 @@
+class_name GrandMother extends Node
+
+var _member:bool = false
+
+func test() -> void :
+	Daughter

--- a/tests/gdscript/cyclic_compilation/main_scene.tscn
+++ b/tests/gdscript/cyclic_compilation/main_scene.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://dvlmwl4fa2lwc"]
+
+[ext_resource type="Script" path="res://mother.gd" id="1_5cvo0"]
+
+[node name="MainScene" type="Node2D"]
+script = ExtResource("1_5cvo0")

--- a/tests/gdscript/cyclic_compilation/mother.gd
+++ b/tests/gdscript/cyclic_compilation/mother.gd
@@ -1,0 +1,1 @@
+class_name Mother extends GrandMother

--- a/tests/gdscript/cyclic_compilation/project.godot
+++ b/tests/gdscript/cyclic_compilation/project.godot
@@ -1,0 +1,16 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="ParseError_Project"
+run/main_scene="res://main_scene.tscn"
+config/features=PackedStringArray("4.1", "Forward Plus")
+config/icon="res://icon.svg"


### PR DESCRIPTION
Adds a GDScript test that requires a very specific order of loading as well as the usage of global class names in order to require other files to be loaded. This cannot be achieved with the current unit testing framework.